### PR TITLE
Added support for _bulk updates

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -25,6 +25,7 @@
         <elastic.version>5.0.0</elastic.version>
         <jtwig.version>5.58</jtwig.version>
         <commons.io.version>2.5</commons.io.version>
+        <commons.collections4.version>4.1</commons.collections4.version>
     </properties>
 
     <dependencies>
@@ -55,6 +56,12 @@
             <groupId>commons-io</groupId>
             <artifactId>commons-io</artifactId>
             <version>${commons.io.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-collections4</artifactId>
+            <version>${commons.collections4.version}</version>
         </dependency>
 
     </dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -24,6 +24,7 @@
         <java.version>1.8</java.version>
         <elastic.version>5.0.0</elastic.version>
         <jtwig.version>5.58</jtwig.version>
+        <commons.io.version>2.5</commons.io.version>
     </properties>
 
     <dependencies>
@@ -48,6 +49,12 @@
             <groupId>org.jtwig</groupId>
             <artifactId>jtwig-core</artifactId>
             <version>${jtwig.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>commons-io</groupId>
+            <artifactId>commons-io</artifactId>
+            <version>${commons.io.version}</version>
         </dependency>
 
     </dependencies>

--- a/src/main/java/eu/luminis/elastic/ElasticRestResponseException.java
+++ b/src/main/java/eu/luminis/elastic/ElasticRestResponseException.java
@@ -1,0 +1,64 @@
+package eu.luminis.elastic;
+
+import org.apache.http.StatusLine;
+
+public abstract class ElasticRestResponseException extends RuntimeException {
+    private final Status status;
+
+    public enum Status {
+        NO_RESPONSE,
+        SERVER_ERROR,
+        NOT_FOUND,
+        BAD_REQUEST,
+        CLIENT_ERROR,
+        UNKNOWN;
+
+        public static Status from(StatusLine statusLine) {
+            if (statusLine == null) {
+                return NO_RESPONSE;
+            }
+            int code = statusLine.getStatusCode();
+            if (code == 400) {
+                return BAD_REQUEST;
+            } else if (code == 404) {
+                return NOT_FOUND;
+            } else if (code > 400 && code <= 500) {
+                return CLIENT_ERROR;
+            } else if (code >= 500) {
+                return SERVER_ERROR;
+            }
+            return  UNKNOWN;
+        }
+
+    }
+
+    public ElasticRestResponseException(StatusLine statusLine) {
+        this(statusLine.getReasonPhrase(), Status.from(statusLine));
+    }
+
+    public ElasticRestResponseException(String message, Status status) {
+        super(message);
+        this.status = status;
+    }
+
+
+    public ElasticRestResponseException(String message) {
+        super(message);
+        this.status = Status.UNKNOWN;
+    }
+
+    public ElasticRestResponseException(String message, Throwable cause) {
+        super(message, cause);
+        this.status = Status.UNKNOWN;
+    }
+
+    public ElasticRestResponseException(Status status, Exception e) {
+        super(e);
+        this.status = status;
+    }
+
+    public Status getStatus() {
+        return status;
+    }
+
+}

--- a/src/main/java/eu/luminis/elastic/document/IndexRequest.java
+++ b/src/main/java/eu/luminis/elastic/document/IndexRequest.java
@@ -4,18 +4,23 @@ package eu.luminis.elastic.document;
  * Created by jettrocoenradie on 23/08/2016.
  */
 public class IndexRequest {
+    public enum Action {
+        INDEX, CREATE, DELETE, UPDATE;
+    }
+
     private String index;
     private String type;
     private String id;
+    private Action action = Action.INDEX;
     private Object entity;
-    private Boolean addId;
+    private boolean update = false;
 
-    public Boolean getAddId() {
-        return addId;
+    public boolean isUpdate() {
+        return update;
     }
 
-    public IndexRequest setAddId(Boolean addId) {
-        this.addId = addId;
+    public IndexRequest setUpdate(boolean update) {
+        this.update = update;
         return this;
     }
 
@@ -55,7 +60,28 @@ public class IndexRequest {
         return this;
     }
 
-    public static IndexRequest create() {
-        return new IndexRequest();
+    public String action() {
+        return this.action.name().toLowerCase();
+    }
+
+    public IndexRequest setAction(Action action) {
+        this.action = action;
+        return this;
+    }
+
+    public IndexRequest create() {
+        return setAction(Action.CREATE);
+    }
+
+    public IndexRequest index() {
+        return setAction(Action.INDEX);
+    }
+
+    public IndexRequest update() {
+        return setAction(Action.UPDATE);
+    }
+
+    public IndexRequest delete() {
+        return setAction(Action.DELETE);
     }
 }

--- a/src/main/java/eu/luminis/elastic/document/IndexRequest.java
+++ b/src/main/java/eu/luminis/elastic/document/IndexRequest.java
@@ -7,7 +7,6 @@ public class IndexRequest {
     public enum Action {
         INDEX, CREATE, DELETE, UPDATE;
     }
-
     private String index;
     private String type;
     private String id;
@@ -20,6 +19,9 @@ public class IndexRequest {
     }
 
     public IndexRequest setUpdate(boolean update) {
+        if (update) {
+            this.action = Action.UPDATE;
+        }
         this.update = update;
         return this;
     }
@@ -66,22 +68,27 @@ public class IndexRequest {
 
     public IndexRequest setAction(Action action) {
         this.action = action;
+        this.update = action == Action.UPDATE;
         return this;
     }
 
-    public IndexRequest create() {
-        return setAction(Action.CREATE);
+    public Action getAction() {
+        return action;
     }
 
-    public IndexRequest index() {
-        return setAction(Action.INDEX);
+    public static IndexRequest create() {
+        return new IndexRequest();
     }
 
-    public IndexRequest update() {
-        return setAction(Action.UPDATE);
-    }
-
-    public IndexRequest delete() {
-        return setAction(Action.DELETE);
+    @Override
+    public String toString() {
+        return "IndexRequest{" +
+                "index='" + index + '\'' +
+                ", type='" + type + '\'' +
+                ", id='" + id + '\'' +
+                ", action=" + action +
+                ", entity=" + entity +
+                ", update=" + update +
+                '}';
     }
 }

--- a/src/main/java/eu/luminis/elastic/index/IndexDocumentException.java
+++ b/src/main/java/eu/luminis/elastic/index/IndexDocumentException.java
@@ -1,9 +1,17 @@
 package eu.luminis.elastic.index;
 
+import eu.luminis.elastic.ElasticRestResponseException;
+import org.apache.http.StatusLine;
+
 /**
  * Created by jettrocoenradie on 16/07/16.
  */
-public class IndexDocumentException extends RuntimeException {
+public class IndexDocumentException extends ElasticRestResponseException {
+
+    public IndexDocumentException(StatusLine statusLine) {
+        super(statusLine);
+    }
+
     public IndexDocumentException(String message) {
         super(message);
     }

--- a/src/main/java/eu/luminis/elastic/index/response/BulkIndexResponse.java
+++ b/src/main/java/eu/luminis/elastic/index/response/BulkIndexResponse.java
@@ -9,7 +9,7 @@ public class BulkIndexResponse {
     private Boolean errors;
 
     @JsonProperty(value = "items")
-    private List<IndexResponse> items;
+    private List<ResponseItem> items;
 
     @JsonProperty(value = "took")
     private Long took;
@@ -22,11 +22,11 @@ public class BulkIndexResponse {
         this.errors = errors;
     }
 
-    public List<IndexResponse> getItems() {
+    public List<ResponseItem> getItems() {
         return items;
     }
 
-    public void setItems(List<IndexResponse> items) {
+    public void setItems(List<ResponseItem> items) {
         this.items = items;
     }
 

--- a/src/main/java/eu/luminis/elastic/index/response/BulkIndexResponse.java
+++ b/src/main/java/eu/luminis/elastic/index/response/BulkIndexResponse.java
@@ -1,0 +1,40 @@
+package eu.luminis.elastic.index.response;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.util.List;
+
+public class BulkIndexResponse {
+    @JsonProperty(value = "errors")
+    private Boolean errors;
+
+    @JsonProperty(value = "items")
+    private List<IndexResponse> items;
+
+    @JsonProperty(value = "took")
+    private Long took;
+
+    public Boolean getErrors() {
+        return errors;
+    }
+
+    public void setErrors(Boolean errors) {
+        this.errors = errors;
+    }
+
+    public List<IndexResponse> getItems() {
+        return items;
+    }
+
+    public void setItems(List<IndexResponse> items) {
+        this.items = items;
+    }
+
+    public Long getTook() {
+        return took;
+    }
+
+    public void setTook(Long took) {
+        this.took = took;
+    }
+}

--- a/src/main/java/eu/luminis/elastic/index/response/CausedBy.java
+++ b/src/main/java/eu/luminis/elastic/index/response/CausedBy.java
@@ -1,0 +1,36 @@
+package eu.luminis.elastic.index.response;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public class CausedBy {
+
+    @JsonProperty(value = "type")
+    private String type;
+
+    @JsonProperty(value = "reason")
+    private String reason;
+
+    public String getType() {
+        return type;
+    }
+
+    public void setType(String type) {
+        this.type = type;
+    }
+
+    public String getReason() {
+        return reason;
+    }
+
+    public void setReason(String reason) {
+        this.reason = reason;
+    }
+
+    @Override
+    public String toString() {
+        return "CausedBy{" +
+                "type='" + type + '\'' +
+                ", reason='" + reason + '\'' +
+                '}';
+    }
+}

--- a/src/main/java/eu/luminis/elastic/index/response/CountResponse.java
+++ b/src/main/java/eu/luminis/elastic/index/response/CountResponse.java
@@ -1,0 +1,29 @@
+package eu.luminis.elastic.index.response;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import nl.gerimedica.ysis.search.elastic.document.response.Shards;
+
+public class CountResponse {
+
+    @JsonProperty(value = "count")
+    private long count;
+
+    @JsonProperty(value = "_shards")
+    private Shards shards;
+
+    public long getCount() {
+        return count;
+    }
+
+    public void setCount(long count) {
+        this.count = count;
+    }
+
+    public Shards getShards() {
+        return shards;
+    }
+
+    public void setShards(Shards shards) {
+        this.shards = shards;
+    }
+}

--- a/src/main/java/eu/luminis/elastic/index/response/Error.java
+++ b/src/main/java/eu/luminis/elastic/index/response/Error.java
@@ -1,0 +1,48 @@
+package eu.luminis.elastic.index.response;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public class Error {
+
+    @JsonProperty(value = "reason")
+    private String reason;
+
+    @JsonProperty(value = "type")
+    private String type;
+
+    @JsonProperty(value = "caused_by")
+    private CausedBy causedBy;
+
+    public String getReason() {
+        return reason;
+    }
+
+    public void setReason(String reason) {
+        this.reason = reason;
+    }
+
+    public String getType() {
+        return type;
+    }
+
+    public void setType(String type) {
+        this.type = type;
+    }
+
+    public CausedBy getCausedBy() {
+        return causedBy;
+    }
+
+    public void setCausedBy(CausedBy causedBy) {
+        this.causedBy = causedBy;
+    }
+
+    @Override
+    public String toString() {
+        return "Error{" +
+                "reason='" + reason + '\'' +
+                ", type='" + type + '\'' +
+                ", causedBy=" + causedBy +
+                '}';
+    }
+}

--- a/src/main/java/eu/luminis/elastic/index/response/IndexResponse.java
+++ b/src/main/java/eu/luminis/elastic/index/response/IndexResponse.java
@@ -1,7 +1,13 @@
 package eu.luminis.elastic.index.response;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import eu.luminis.elastic.document.response.Shards;
 
+/**
+ * By Jettro Coenradie
+ *
+ * https://github.com/luminis-ams/elastic-rest-spring-wrapper/blob/master/LICENSE
+ */
 public class IndexResponse {
     @JsonProperty(value = "_index")
     private String index;
@@ -15,11 +21,28 @@ public class IndexResponse {
     @JsonProperty(value = "_version")
     private long version;
 
+    @JsonProperty(value = "_shards")
+    private Shards shards;
+
     @JsonProperty(value = "result")
     private String result;
 
     @JsonProperty(value = "created")
     private Boolean created;
+
+    @JsonProperty(value = "error")
+    private Error error;
+
+    @JsonProperty(value = "status")
+    private int status;
+
+    public int getStatus() {
+        return status;
+    }
+
+    public void setStatus(int status) {
+        this.status = status;
+    }
 
     public String getIndex() {
         return index;
@@ -67,5 +90,21 @@ public class IndexResponse {
 
     public void setCreated(Boolean created) {
         this.created = created;
+    }
+
+    public Error getError() {
+        return error;
+    }
+
+    public void setError(Error error) {
+        this.error = error;
+    }
+
+    public Shards getShards() {
+        return shards;
+    }
+
+    public void setShards(Shards shards) {
+        this.shards = shards;
     }
 }

--- a/src/main/java/eu/luminis/elastic/index/response/ResponseItem.java
+++ b/src/main/java/eu/luminis/elastic/index/response/ResponseItem.java
@@ -1,0 +1,16 @@
+package eu.luminis.elastic.index.response;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public class ResponseItem {
+    @JsonProperty(value = "index")
+    private IndexResponse index;
+
+    public IndexResponse getIndex() {
+        return index;
+    }
+
+    public void setIndex(IndexResponse index) {
+        this.index = index;
+    }
+}


### PR DESCRIPTION
This might break existing code (I don't have any to test with), it changes how IndexRequests work. 

```
new IndexRequest()
                            .setId("document_1")
                            .setIndex("index_name")
                            .setType("document_type")
                            .setAction(IndexRequest.Action.UPDATE)
                            .setEntity(entity);   

```

The actions correspond to ES syntax index, update, create and delete. Index is default. 

BATCH_SIZE is the number of documents to be indexed per _bulk request. In some non-scientific tests, I've found that for my data set, performance rapidly drops off with a batch size smaller than 1000, but does not increase measurably by increasing it further, until finally it gets so large that ES throws an error. 